### PR TITLE
Support zero copy introduced from Deno 1.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 env:
-  DENO_VERSION: 1.x
+  DENO_DIR: ".deno"
 
 on:
   schedule:
@@ -14,46 +14,64 @@ on:
       - main
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
+  check:
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-latest
+        version:
+          - "1.x"
+    runs-on: ${{ matrix.runner }}
     steps:
+      - run: git config --global core.autocrlf false
+        if: runner.os == 'Windows'
       - uses: actions/checkout@v2
-      - uses: denoland/setup-deno@main
+      - uses: denoland/setup-deno@v1
         with:
-          deno-version: ${{ env.DENO_VERSION }}
-      - name: Lint
-        run: deno lint
-
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: denoland/setup-deno@main
+          deno-version: "${{ matrix.version }}"
+      - uses: actions/cache@v2
         with:
-          deno-version: ${{ env.DENO_VERSION }}
-      - name: Format
+          path: ${{ env.DENO_DIR }}
+          key: ${{ runner.os }}-deno-${{ matrix.version }}-${{ hashFiles('**/*.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-${{ matrix.version }}-
+            ${{ runner.os }}-deno-
+      - name: Lint check
         run: |
-          deno fmt --check
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: denoland/setup-deno@main
-        with:
-          deno-version: ${{ env.DENO_VERSION }}
-      - name: Test
+          make lint
+      - name: Format check
         run: |
-          deno test --no-check --unstable --allow-read --allow-net
-        timeout-minutes: 5
-
-  typecheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: denoland/setup-deno@main
-        with:
-          deno-version: ${{ env.DENO_VERSION }}
+          make fmt-check
       - name: Type check
         run: |
-          deno test --unstable --no-run ./*.ts
+          make type-check
+
+  test:
+    strategy:
+      matrix:
+        runner:
+          - windows-latest
+          - macos-latest
+          - ubuntu-latest
+        version:
+          - "1.x"
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - run: git config --global core.autocrlf false
+        if: runner.os == 'Windows'
+      - uses: actions/checkout@v2
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: "${{ matrix.version }}"
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: ${{ env.DENO_DIR }}
+          key: ${{ runner.os }}-deno-${{ matrix.version }}-${{ hashFiles('**/*.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-${{ matrix.version }}-
+            ${{ runner.os }}-deno-
+      - name: Test
+        run: |
+          make test
+        timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         version:
           - "1.x"
           - "1.13.x"
+          - "1.14.x"
     runs-on: ${{ matrix.runner }}
     steps:
       - run: git config --global core.autocrlf false
@@ -57,6 +58,7 @@ jobs:
         version:
           - "1.x"
           - "1.13.x"
+          - "1.14.x"
     runs-on: ${{ matrix.runner }}
     steps:
       - run: git config --global core.autocrlf false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
           - ubuntu-latest
         version:
           - "1.x"
+          - "1.13.x"
     runs-on: ${{ matrix.runner }}
     steps:
       - run: git config --global core.autocrlf false
@@ -55,6 +56,7 @@ jobs:
           - ubuntu-latest
         version:
           - "1.x"
+          - "1.13.x"
     runs-on: ${{ matrix.runner }}
     steps:
       - run: git config --global core.autocrlf false

--- a/.github/workflows/udd.yml
+++ b/.github/workflows/udd.yml
@@ -1,0 +1,28 @@
+name: udd
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  udd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: "1.x"
+      - run: |
+          make tools
+          make update
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: ":package: Update deno dependencies"
+          title: ":package: Update deno dependencies"
+          body: |
+            Automated updates by [deno-udd](https://github.com/hayd/deno-udd)
+            and [create-pull-request](https://github.com/peter-evans/create-pull-request)
+            GitHub action
+          branch: update-deno-dependencies
+          author: GitHub <noreply@github.com>
+          delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.tool-versions
+/.tools

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+TOOLS := ${CURDIR}/.tools
+
+.DEFAULT_GOAL := help
+
+help:
+	@cat $(MAKEFILE_LIST) | \
+	    perl -ne 'print if /^\w+.*##/;' | \
+	    perl -pe 's/(.*):.*##\s*/sprintf("%-20s",$$1)/eg;'
+
+tools: FORCE	## Install development tools
+	@mkdir -p ${TOOLS}
+	@deno install -A -f -n udd --root ${TOOLS} https://deno.land/x/udd@0.5.0/main.ts
+
+fmt: FORCE	## Format code
+	@deno fmt --ignore=.deno
+
+fmt-check: FORCE	## Format check
+	@deno fmt --check --ignore=.deno
+
+lint: FORCE	## Lint code
+	@deno lint --ignore=.deno
+
+type-check: FORCE	## Type check
+	@deno test --unstable --no-run $$(find . -name '*.ts' -not -name '.deno')
+
+test: FORCE	## Test
+	@deno test --no-check --unstable -A --jobs
+
+update: FORCE	## Update dependencies
+	@${TOOLS}/bin/udd $$(find . -name '*.ts' -not -name '.deno')
+	@make fmt
+
+FORCE:

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@
 [Deno][deno] module to translate Worker's system of messages into
 [Reader][reader] and [Writer][writer].
 
+This module supports Deno v1.13.0 or later.
+
 Note that this package requires
 [`Worker.postMessage` supports structured clone
-algorithm](https://deno.com/blog/v1.10#worker.postmessage-supports-structured-clone-algorithm)
-introduced in Deno v1.10.
+algorithm](https://deno.com/blog/v1.10#worker.postmessage-supports-structured-clone-algorithm).
 
 Note that this package accesses `Deno` namespace thus
 [Using Deno in worker](https://deno.land/manual@v1.11.0/runtime/workers#using-deno-in-worker)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@
 [Deno][deno] module to translate Worker's system of messages into
 [Reader][reader] and [Writer][writer].
 
-This module supports Deno v1.13.0 or later.
+This module supports Deno v1.13.0 or later. The
+[Zero-copy ArrayBuffer transfers between
+workers](https://deno.com/blog/v1.14#zero-copy-arraybuffer-transfers-between-workers)
+is supported from Deno 1.14.0.
 
 Note that this package requires
 [`Worker.postMessage` supports structured clone

--- a/benchmark/benchmark.ts
+++ b/benchmark/benchmark.ts
@@ -46,7 +46,7 @@ async function main(): Promise<void> {
     string: ["n", "size"],
     default: {
       n: 5,
-      size: 1,
+      size: 10,
     },
   });
   const worker = new Worker(

--- a/benchmark/benchmark.ts
+++ b/benchmark/benchmark.ts
@@ -1,4 +1,4 @@
-import { parse } from "https://deno.land/std@0.98.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.107.0/flags/mod.ts";
 import { assertEquals, delay, io } from "../deps_test.ts";
 import { WorkerReader, WorkerWriter } from "../mod.ts";
 

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,5 @@
 export { Queue } from "https://deno.land/x/async@v1.0/queue.ts";
 export { deferred } from "https://deno.land/std@0.107.0/async/mod.ts";
 export type { Deferred } from "https://deno.land/std@0.107.0/async/mod.ts";
+
+export { compareVersions } from "https://deno.land/x/compare_versions@0.4.0/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,3 @@
 export { Queue } from "https://deno.land/x/async@v1.0/queue.ts";
-export { deferred } from "https://deno.land/std@0.98.0/async/mod.ts";
-export type { Deferred } from "https://deno.land/std@0.98.0/async/mod.ts";
+export { deferred } from "https://deno.land/std@0.107.0/async/mod.ts";
+export type { Deferred } from "https://deno.land/std@0.107.0/async/mod.ts";

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,3 +1,3 @@
-export * from "https://deno.land/std@0.98.0/testing/asserts.ts";
-export * as io from "https://deno.land/std@0.98.0/io/mod.ts";
-export { delay } from "https://deno.land/std@0.98.0/async/mod.ts";
+export * from "https://deno.land/std@0.107.0/testing/asserts.ts";
+export * as io from "https://deno.land/std@0.107.0/io/mod.ts";
+export { delay } from "https://deno.land/std@0.107.0/async/mod.ts";

--- a/example/server.ts
+++ b/example/server.ts
@@ -1,4 +1,4 @@
-import * as io from "https://deno.land/std@0.93.0/io/mod.ts";
+import * as io from "https://deno.land/std@0.107.0/io/mod.ts";
 import { WorkerReader, WorkerWriter } from "../mod.ts";
 
 const decoder = new TextDecoder();

--- a/example/worker.ts
+++ b/example/worker.ts
@@ -1,4 +1,4 @@
-import * as io from "https://deno.land/std@0.93.0/io/mod.ts";
+import * as io from "https://deno.land/std@0.107.0/io/mod.ts";
 import { WorkerReader, WorkerWriter } from "../mod.ts";
 
 const decoder = new TextDecoder();

--- a/types.ts
+++ b/types.ts
@@ -1,10 +1,2 @@
-type Payload = Uint8Array;
-
-export type WorkerForWorkerReader = {
-  onmessage?: (message: MessageEvent<Payload>) => void;
-  terminate(): void;
-};
-
-export type WorkerForWorkerWriter = {
-  postMessage(message: Payload): void;
-};
+export type WorkerForWorkerReader = Pick<Worker, "onmessage" | "terminate">;
+export type WorkerForWorkerWriter = Pick<Worker, "postMessage">;


### PR DESCRIPTION
https://deno.com/blog/v1.14#zero-copy-arraybuffer-transfers-between-workers

Close #7 

### Deno 1.13.0

```
===========================================================
Transfer: 10 MiB
N:        5 times
===========================================================
Relaxing 1 sec ...
Start benchmark
1 Reader: 50 [ms] Writer: 14 [ms]
2 Reader: 45 [ms] Writer: 9 [ms]
3 Reader: 48 [ms] Writer: 6 [ms]
4 Reader: 27 [ms] Writer: 2 [ms]
5 Reader: 46 [ms] Writer: 9 [ms]
===========================================================
Reader: Avg. 43.200 msec (1941.8 Mbps)
Writer: Avg. 8.0000 msec (10486 Mbps)
===========================================================
```

### Deno 1.14.0

```
===========================================================
Transfer: 10 MiB
N:        5 times
===========================================================
Relaxing 1 sec ...
Start benchmark
1 Reader: 46 [ms] Writer: 8 [ms]
2 Reader: 37 [ms] Writer: 4 [ms]
3 Reader: 36 [ms] Writer: 4 [ms]
4 Reader: 35 [ms] Writer: 4 [ms]
5 Reader: 37 [ms] Writer: 5 [ms]
===========================================================
Reader: Avg. 38.200 msec (2196.0 Mbps)
Writer: Avg. 5.0000 msec (16777 Mbps)
===========================================================
```