### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/benchmark/benchmark.ts
+++ b/benchmark/benchmark.ts
@@ -1,4 +1,4 @@
-import { parse } from "https://deno.land/std@0.110.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.127.0/flags/mod.ts";
 import { assertEquals, delay, io } from "../deps_test.ts";
 import { WorkerReader, WorkerWriter } from "../mod.ts";
 

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
 export { Queue } from "https://deno.land/x/async@v1.0/queue.ts";
-export { deferred } from "https://deno.land/std@0.110.0/async/mod.ts";
-export type { Deferred } from "https://deno.land/std@0.110.0/async/mod.ts";
+export { deferred } from "https://deno.land/std@0.127.0/async/mod.ts";
+export type { Deferred } from "https://deno.land/std@0.127.0/async/mod.ts";
 
 export { compareVersions } from "https://deno.land/x/compare_versions@0.4.0/mod.ts";

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,3 +1,3 @@
-export * from "https://deno.land/std@0.110.0/testing/asserts.ts";
-export * as io from "https://deno.land/std@0.110.0/io/mod.ts";
-export { delay } from "https://deno.land/std@0.110.0/async/mod.ts";
+export * from "https://deno.land/std@0.127.0/testing/asserts.ts";
+export * as io from "https://deno.land/std@0.127.0/io/mod.ts";
+export { delay } from "https://deno.land/std@0.127.0/async/mod.ts";

--- a/example/server.ts
+++ b/example/server.ts
@@ -1,4 +1,4 @@
-import * as io from "https://deno.land/std@0.110.0/io/mod.ts";
+import * as io from "https://deno.land/std@0.127.0/io/mod.ts";
 import { WorkerReader, WorkerWriter } from "../mod.ts";
 
 const decoder = new TextDecoder();

--- a/example/worker.ts
+++ b/example/worker.ts
@@ -1,4 +1,4 @@
-import * as io from "https://deno.land/std@0.110.0/io/mod.ts";
+import * as io from "https://deno.land/std@0.127.0/io/mod.ts";
 import { WorkerReader, WorkerWriter } from "../mod.ts";
 
 const decoder = new TextDecoder();


### PR DESCRIPTION
The output of `make update` is

```
./example/server.ts
[1/1] Looking for releases: https://deno.land/std@0.110.0/io/mod.ts
[1/1] Attempting update: https://deno.land/std@0.110.0/io/mod.ts -> 0.127.0
[1/1] Update successful: https://deno.land/std@0.110.0/io/mod.ts -> 0.127.0

./example/worker.ts
[1/1] Looking for releases: https://deno.land/std@0.110.0/io/mod.ts
[1/1] Attempting update: https://deno.land/std@0.110.0/io/mod.ts -> 0.127.0
[1/1] Update successful: https://deno.land/std@0.110.0/io/mod.ts -> 0.127.0

./test_worker.ts

./deps.ts
[1/4] Looking for releases: https://deno.land/x/async@v1.0/queue.ts
[1/4] Skip updating: https://deno.land/x/async@v1.0/queue.ts
[2/4] Looking for releases: https://deno.land/std@0.110.0/async/mod.ts
[2/4] Attempting update: https://deno.land/std@0.110.0/async/mod.ts -> 0.127.0
[2/4] Update successful: https://deno.land/std@0.110.0/async/mod.ts -> 0.127.0
[3/4] Looking for releases: https://deno.land/std@0.110.0/async/mod.ts
[3/4] Attempting update: https://deno.land/std@0.110.0/async/mod.ts -> 0.127.0
[3/4] Update successful: https://deno.land/std@0.110.0/async/mod.ts -> 0.127.0
[4/4] Looking for releases: https://deno.land/x/compare_versions@0.4.0/mod.ts
[4/4] Using latest: https://deno.land/x/compare_versions@0.4.0/mod.ts

./test.ts

./writer_test.ts

./mod.ts

./writer.ts

./benchmark/benchmark.ts
[1/1] Looking for releases: https://deno.land/std@0.110.0/flags/mod.ts
[1/1] Attempting update: https://deno.land/std@0.110.0/flags/mod.ts -> 0.127.0
[1/1] Update successful: https://deno.land/std@0.110.0/flags/mod.ts -> 0.127.0

./reader.ts

./deps_test.ts
[1/3] Looking for releases: https://deno.land/std@0.110.0/testing/asserts.ts
[1/3] Attempting update: https://deno.land/std@0.110.0/testing/asserts.ts -> 0.127.0
[1/3] Update successful: https://deno.land/std@0.110.0/testing/asserts.ts -> 0.127.0
[2/3] Looking for releases: https://deno.land/std@0.110.0/io/mod.ts
[2/3] Attempting update: https://deno.land/std@0.110.0/io/mod.ts -> 0.127.0
[2/3] Update successful: https://deno.land/std@0.110.0/io/mod.ts -> 0.127.0
[3/3] Looking for releases: https://deno.land/std@0.110.0/async/mod.ts
[3/3] Attempting update: https://deno.land/std@0.110.0/async/mod.ts -> 0.127.0
[3/3] Update successful: https://deno.land/std@0.110.0/async/mod.ts -> 0.127.0

./types.ts

./reader_test.ts

Already latest version:
https://deno.land/x/async@v1.0/queue.ts == v1.0
https://deno.land/x/compare_versions@0.4.0/mod.ts == 0.4.0

Successfully updated:
https://deno.land/std@0.110.0/io/mod.ts 0.110.0 -> 0.127.0
https://deno.land/std@0.110.0/io/mod.ts 0.110.0 -> 0.127.0
https://deno.land/std@0.110.0/async/mod.ts 0.110.0 -> 0.127.0
https://deno.land/std@0.110.0/async/mod.ts 0.110.0 -> 0.127.0
https://deno.land/std@0.110.0/flags/mod.ts 0.110.0 -> 0.127.0
https://deno.land/std@0.110.0/testing/asserts.ts 0.110.0 -> 0.127.0
https://deno.land/std@0.110.0/io/mod.ts 0.110.0 -> 0.127.0
https://deno.land/std@0.110.0/async/mod.ts 0.110.0 -> 0.127.0
make[1]: Entering directory '/home/runner/work/deno-workerio/deno-workerio'
make[1]: Leaving directory '/home/runner/work/deno-workerio/deno-workerio'

```