### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/example/server.ts
+++ b/example/server.ts
@@ -1,4 +1,4 @@
-import * as streams from "https://deno.land/std@0.186.0/streams/mod.ts";
+import * as streams from "https://deno.land/std@0.224.0/streams/mod.ts";
 import { WorkerReader, WorkerWriter } from "../mod.ts";
 
 const decoder = new TextDecoder();

--- a/example/worker.ts
+++ b/example/worker.ts
@@ -1,4 +1,4 @@
-import * as streams from "https://deno.land/std@0.186.0/streams/mod.ts";
+import * as streams from "https://deno.land/std@0.224.0/streams/mod.ts";
 import { WorkerReader, WorkerWriter } from "../mod.ts";
 
 const decoder = new TextDecoder();

--- a/readable_stream_bench.ts
+++ b/readable_stream_bench.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
 import { readableStreamFromWorker, WorkerReader } from "./mod.ts";
 import { MockWorker } from "./test_util.ts";
 

--- a/readable_stream_test.ts
+++ b/readable_stream_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
-import { concat } from "https://deno.land/std@0.186.0/bytes/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { concat } from "https://deno.land/std@0.224.0/bytes/mod.ts";
 import { readableStreamFromWorker } from "./mod.ts";
 import { MockWorker } from "./test_util.ts";
 

--- a/reader.ts
+++ b/reader.ts
@@ -1,4 +1,4 @@
-import { Notify } from "https://deno.land/x/async@v2.0.2/notify.ts";
+import { Notify } from "https://deno.land/x/async@v2.1.0/notify.ts";
 
 /**
  * A `WorkerReader` is a `Deno.Reader` and `Deno.Closer` that reads data from a `Worker`.

--- a/reader_bench.ts
+++ b/reader_bench.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
-import { WorkerReader as WorkerReaderV2 } from "https://deno.land/x/workerio@v3.0.1/mod.ts";
-import { WorkerReader as WorkerReaderV1 } from "https://deno.land/x/workerio@v3.0.1/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { WorkerReader as WorkerReaderV2 } from "https://deno.land/x/workerio@v3.1.0/mod.ts";
+import { WorkerReader as WorkerReaderV1 } from "https://deno.land/x/workerio@v3.1.0/mod.ts";
 import { WorkerReader } from "./mod.ts";
 import { MockWorker } from "./test_util.ts";
 

--- a/reader_test.ts
+++ b/reader_test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
-import { delay } from "https://deno.land/std@0.186.0/async/mod.ts";
-import * as streams from "https://deno.land/std@0.186.0/streams/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { delay } from "https://deno.land/std@0.224.0/async/mod.ts";
+import * as streams from "https://deno.land/std@0.224.0/streams/mod.ts";
 import { WorkerReader } from "./mod.ts";
 import { MockWorker } from "./test_util.ts";
 

--- a/test_bench.ts
+++ b/test_bench.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
 import {
   readableStreamFromWorker,
   WorkerReader,

--- a/writable_stream_bench.ts
+++ b/writable_stream_bench.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertInstanceOf,
-} from "https://deno.land/std@0.186.0/testing/asserts.ts";
+} from "https://deno.land/std@0.224.0/testing/asserts.ts";
 import { WorkerWriter, writableStreamFromWorker } from "./mod.ts";
 import { MockWorker } from "./test_util.ts";
 

--- a/writable_stream_test.ts
+++ b/writable_stream_test.ts
@@ -1,8 +1,8 @@
 import {
   assertEquals,
   assertInstanceOf,
-} from "https://deno.land/std@0.186.0/testing/asserts.ts";
-import { concat } from "https://deno.land/std@0.186.0/bytes/mod.ts";
+} from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { concat } from "https://deno.land/std@0.224.0/bytes/mod.ts";
 import { writableStreamFromWorker } from "./mod.ts";
 import { MockWorker } from "./test_util.ts";
 

--- a/writer_bench.ts
+++ b/writer_bench.ts
@@ -1,9 +1,9 @@
 import {
   assertEquals,
   assertInstanceOf,
-} from "https://deno.land/std@0.186.0/testing/asserts.ts";
-import { WorkerWriter as WorkerWriterV2 } from "https://deno.land/x/workerio@v3.0.1/mod.ts";
-import { WorkerWriter as WorkerWriterV1 } from "https://deno.land/x/workerio@v3.0.1/mod.ts";
+} from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { WorkerWriter as WorkerWriterV2 } from "https://deno.land/x/workerio@v3.1.0/mod.ts";
+import { WorkerWriter as WorkerWriterV1 } from "https://deno.land/x/workerio@v3.1.0/mod.ts";
 import { WorkerWriter } from "./mod.ts";
 import { MockWorker } from "./test_util.ts";
 

--- a/writer_test.ts
+++ b/writer_test.ts
@@ -1,8 +1,8 @@
 import {
   assertEquals,
   assertInstanceOf,
-} from "https://deno.land/std@0.186.0/testing/asserts.ts";
-import { concat } from "https://deno.land/std@0.186.0/bytes/mod.ts";
+} from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { concat } from "https://deno.land/std@0.224.0/bytes/mod.ts";
 import { WorkerWriter } from "./mod.ts";
 import { MockWorker } from "./test_util.ts";
 


### PR DESCRIPTION
The output of `make update` is

```
/home/runner/work/deno-workerio/deno-workerio/writer_bench.ts
[1/3] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/3] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[1/3] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[2/3] Looking for releases: https://deno.land/x/workerio@v3.0.1/mod.ts
[2/3] Attempting update: https://deno.land/x/workerio@v3.0.1/mod.ts -> v3.1.0
[2/3] Update successful: https://deno.land/x/workerio@v3.0.1/mod.ts -> v3.1.0
[3/3] Looking for releases: https://deno.land/x/workerio@v3.0.1/mod.ts
[3/3] Attempting update: https://deno.land/x/workerio@v3.0.1/mod.ts -> v3.1.0
[3/3] Update successful: https://deno.land/x/workerio@v3.0.1/mod.ts -> v3.1.0

/home/runner/work/deno-workerio/deno-workerio/writable_stream.ts

/home/runner/work/deno-workerio/deno-workerio/readable_stream_bench.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[1/1] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0

/home/runner/work/deno-workerio/deno-workerio/reader_test.ts
[1/3] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/3] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[1/3] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[2/3] Looking for releases: https://deno.land/std@0.186.0/async/mod.ts
[2/3] Attempting update: https://deno.land/std@0.186.0/async/mod.ts -> 0.224.0
[2/3] Update successful: https://deno.land/std@0.186.0/async/mod.ts -> 0.224.0
[3/3] Looking for releases: https://deno.land/std@0.186.0/streams/mod.ts
[3/3] Attempting update: https://deno.land/std@0.186.0/streams/mod.ts -> 0.224.0
[3/3] Update successful: https://deno.land/std@0.186.0/streams/mod.ts -> 0.224.0

/home/runner/work/deno-workerio/deno-workerio/writable_stream_test.ts
[1/2] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[1/2] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[2/2] Looking for releases: https://deno.land/std@0.186.0/bytes/mod.ts
[2/2] Attempting update: https://deno.land/std@0.186.0/bytes/mod.ts -> 0.224.0
[2/2] Update successful: https://deno.land/std@0.186.0/bytes/mod.ts -> 0.224.0

/home/runner/work/deno-workerio/deno-workerio/test_echo_server.ts

/home/runner/work/deno-workerio/deno-workerio/writer_test.ts
[1/2] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[1/2] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[2/2] Looking for releases: https://deno.land/std@0.186.0/bytes/mod.ts
[2/2] Attempting update: https://deno.land/std@0.186.0/bytes/mod.ts -> 0.224.0
[2/2] Update successful: https://deno.land/std@0.186.0/bytes/mod.ts -> 0.224.0

/home/runner/work/deno-workerio/deno-workerio/example/worker.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/streams/mod.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/streams/mod.ts -> 0.224.0
[1/1] Update successful: https://deno.land/std@0.186.0/streams/mod.ts -> 0.224.0

/home/runner/work/deno-workerio/deno-workerio/example/server.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/streams/mod.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/streams/mod.ts -> 0.224.0
[1/1] Update successful: https://deno.land/std@0.186.0/streams/mod.ts -> 0.224.0

/home/runner/work/deno-workerio/deno-workerio/writer.ts

/home/runner/work/deno-workerio/deno-workerio/test_util.ts

/home/runner/work/deno-workerio/deno-workerio/writable_stream_bench.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[1/1] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0

/home/runner/work/deno-workerio/deno-workerio/mod.ts

/home/runner/work/deno-workerio/deno-workerio/readable_stream.ts

/home/runner/work/deno-workerio/deno-workerio/reader_bench.ts
[1/3] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/3] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[1/3] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[2/3] Looking for releases: https://deno.land/x/workerio@v3.0.1/mod.ts
[2/3] Attempting update: https://deno.land/x/workerio@v3.0.1/mod.ts -> v3.1.0
[2/3] Update successful: https://deno.land/x/workerio@v3.0.1/mod.ts -> v3.1.0
[3/3] Looking for releases: https://deno.land/x/workerio@v3.0.1/mod.ts
[3/3] Attempting update: https://deno.land/x/workerio@v3.0.1/mod.ts -> v3.1.0
[3/3] Update successful: https://deno.land/x/workerio@v3.0.1/mod.ts -> v3.1.0

/home/runner/work/deno-workerio/deno-workerio/readable_stream_test.ts
[1/2] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[1/2] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[2/2] Looking for releases: https://deno.land/std@0.186.0/bytes/mod.ts
[2/2] Attempting update: https://deno.land/std@0.186.0/bytes/mod.ts -> 0.224.0
[2/2] Update successful: https://deno.land/std@0.186.0/bytes/mod.ts -> 0.224.0

/home/runner/work/deno-workerio/deno-workerio/test_bench.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0
[1/1] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.224.0

/home/runner/work/deno-workerio/deno-workerio/reader.ts
[1/1] Looking for releases: https://deno.land/x/async@v2.0.2/notify.ts
[1/1] Attempting update: https://deno.land/x/async@v2.0.2/notify.ts -> v2.1.0
[1/1] Update successful: https://deno.land/x/async@v2.0.2/notify.ts -> v2.1.0

Successfully updated:
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.224.0
https://deno.land/x/workerio@v3.0.1/mod.ts v3.0.1 -> v3.1.0
https://deno.land/x/workerio@v3.0.1/mod.ts v3.0.1 -> v3.1.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/async/mod.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/streams/mod.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/bytes/mod.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/bytes/mod.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/streams/mod.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/streams/mod.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.224.0
https://deno.land/x/workerio@v3.0.1/mod.ts v3.0.1 -> v3.1.0
https://deno.land/x/workerio@v3.0.1/mod.ts v3.0.1 -> v3.1.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/bytes/mod.ts 0.186.0 -> 0.224.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.224.0
https://deno.land/x/async@v2.0.2/notify.ts v2.0.2 -> v2.1.0

```