### PR TITLE
Fix update task

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -5,44 +5,17 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+
       - uses: actions/checkout@v4
-      - uses: denoland/setup-deno@v1
+
+      - uses: hasundue/molt-action@v1-rc
         with:
-          deno-version: 1.x
-      - name: Configure Git
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-      - name: Update dependencies and commit changes
-        run: deno task -q update:commit --summary ../title.txt --report ../body.md
-      - name: Check result
-        id: result
-        uses: andstor/file-existence-action@v2
-        with:
-          files: ../title.txt, ../body.md
-      - name: Read title.txt
-        id: title
-        if: steps.result.outputs.files_exists == 'true'
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ../title.txt
-      - name: Read body.md
-        id: body
-        if: steps.result.outputs.files_exists == 'true'
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ../body.md
-      - name: Create a pull request
-        if: steps.result.outputs.files_exists == 'true'
-        uses: peter-evans/create-pull-request@v6
-        with:
-          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-          branch: automation/update-dependencies
-          title: ${{ steps.title.outputs.content }}
-          body: ${{ steps.body.outputs.content }}
-          labels: automation
-          delete-branch: true
+          source: deno.jsonc

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -23,12 +23,12 @@
     "test:coverage": "deno task test --coverage=.coverage",
     "coverage": "deno coverage .coverage",
     "bench": "deno bench -A",
-    "update": "deno run --allow-env --allow-read --allow-write=. --allow-run=git,deno --allow-net=jsr.io,registry.npmjs.org jsr:@molt/cli ./*.ts",
+    "update": "deno run --allow-env --allow-read --allow-write=. --allow-run=git,deno --allow-net=jsr.io,registry.npmjs.org jsr:@molt/cli deno.jsonc",
     "update:commit": "deno task -q update --commit --pre-commit=fmt,lint"
   },
   "imports": {
-    "@std/assert": "jsr:@std/assert@^0.225.1",
-    "@std/bytes": "jsr:@std/bytes@^0.224.0",
+    "@std/assert": "jsr:@std/assert@0.225.1",
+    "@std/bytes": "jsr:@std/bytes@0.224.0",
     "@lambdalisue/workerio": "./mod.ts"
   }
 }


### PR DESCRIPTION
- Versions only specified in *deno.jsonc*, so change target.
- Version specification with `^` is not updated by *molt*, so remove it.
- Change update workflow to use `molt/action`
  - `--summary` or `--report` are no longer supported in `@molt/cli`.
  - `molt-action` is currently at v1-rc and seems to work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to streamline steps and improve efficiency.
  - Modified dependency version specifications for better stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->