### PR TITLE
feat: allows `WorkerLike`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ for await (const data of reader) {
 #### Worker
 
 ```typescript
+/// <reference no-default-lib="true" />
+/// <reference lib="deno.worker" />
+
 import {
   readableStreamFromWorker,
   writableStreamFromWorker,
@@ -55,9 +58,8 @@ const decoder = new TextDecoder();
 const encoder = new TextEncoder();
 
 async function main(): Promise<void> {
-  const worker = self as unknown as Worker;
-  const reader = readableStreamFromWorker(worker);
-  const writer = writableStreamFromWorker(worker);
+  const reader = readableStreamFromWorker(self);
+  const writer = writableStreamFromWorker(self);
   const w = writer.getWriter();
 
   for await (const data of reader) {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,7 +4,8 @@
   "exports": {
     ".": "./mod.ts",
     "./readable_stream": "./readable_stream.ts",
-    "./writable_stream": "./writable_stream.ts"
+    "./writable_stream": "./writable_stream.ts",
+    "./types": "./types.ts"
   },
   "publish": {
     "exclude": [

--- a/mod.ts
+++ b/mod.ts
@@ -41,6 +41,9 @@
  * #### Worker
  *
  * ```typescript
+ * /// <reference no-default-lib="true" />
+ * /// <reference lib="deno.worker" />
+ *
  * import {
  *   readableStreamFromWorker,
  *   writableStreamFromWorker,
@@ -50,9 +53,8 @@
  * const encoder = new TextEncoder();
  *
  * async function main(): Promise<void> {
- *   const worker = self as unknown as Worker;
- *   const reader = readableStreamFromWorker(worker);
- *   const writer = writableStreamFromWorker(worker);
+ *   const reader = readableStreamFromWorker(self);
+ *   const writer = writableStreamFromWorker(self);
  *   const w = writer.getWriter();
  *
  *   for await (const data of reader) {
@@ -69,3 +71,4 @@
  */
 export * from "./readable_stream.ts";
 export * from "./writable_stream.ts";
+export type * from "./types.ts";

--- a/readable_stream.ts
+++ b/readable_stream.ts
@@ -1,3 +1,5 @@
+import type { WorkerLike } from "./types.ts";
+
 /**
  * Options for creating a readable stream from a worker.
  */
@@ -16,7 +18,7 @@ export type ReadableStreamFromWorkerOptions = {
  * @returns A readable stream that can be used to read the data.
  */
 export function readableStreamFromWorker(
-  worker: Worker,
+  worker: WorkerLike,
   options: ReadableStreamFromWorkerOptions = {},
 ): ReadableStream<Uint8Array> {
   const {

--- a/test_echo_server.ts
+++ b/test_echo_server.ts
@@ -1,4 +1,6 @@
-const worker = self as unknown as Worker;
-worker.onmessage = (ev) => {
-  worker.postMessage(ev.data);
+/// <reference no-default-lib="true" />
+/// <reference lib="deno.worker" />
+
+self.onmessage = (ev) => {
+  self.postMessage(ev.data);
 };

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,7 @@
+/** Worker like object. */
+export type WorkerLike = {
+  // deno-lint-ignore no-explicit-any
+  onmessage: ((ev: MessageEvent) => any) | null;
+  // deno-lint-ignore no-explicit-any
+  postMessage(message: any, transfer?: Transferable[]): void;
+};

--- a/writable_stream.ts
+++ b/writable_stream.ts
@@ -1,3 +1,5 @@
+import type { WorkerLike } from "./types.ts";
+
 /**
  * Options for creating a writable stream from a worker.
  */
@@ -15,7 +17,7 @@ export type WritableStreamFromWorkerOptions = {
  * @returns A new `WritableStream` instance.
  */
 export function writableStreamFromWorker(
-  worker: Worker,
+  worker: WorkerLike,
   options: WritableStreamFromWorkerOptions = {},
 ): WritableStream<Uint8Array> {
   const {


### PR DESCRIPTION
There is no need to force-cast `self as unknown as Worker` in worker environment source files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new type `WorkerLike` for enhanced flexibility in stream creation from workers.

- **Updates**
  - Updated worker-related functions to use `self` instead of `worker` for message handling.
  - Added references to Deno worker libraries in relevant files.
  - Exported types from `types.ts` for broader usage.

- **Documentation**
  - Updated README to reflect changes in worker initialization and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->